### PR TITLE
Bump platformVersion and Java

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The roadmap can be found on the [Toggler board](https://github.com/users/Noorts/
 2. Set up your development environment (I use [IntelliJ IDEA](https://www.jetbrains.com/idea/) for Toggler's development).
    * Open the project and load the Gradle project. A notification should show up in the bottom right indicating
 "Gradle build scripts found".
-   * Install Java 11 and make sure it's set as the SDK and language level in the
+   * Install Java 17 (see `javaVersion` in `gradle.properties`) and make sure it is set as the SDK and language level in the
 [project structure settings](https://www.jetbrains.com/help/idea/project-settings-and-structure.html).
 3. Verify whether you're ready to start development by running the development IDE through Gradle's `runIde` task.
 This task should be available under `Toggler/Tasks/intellij` in

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,23 +12,23 @@ pluginVersion = 1.3.1
 # Build number chosen based on product version statistics:
 # https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html
 # https://intellij-support.jetbrains.com/hc/en-us/community/posts/14610689926674/comments/14625872002706
-pluginSinceBuild = 211
+pluginSinceBuild = 223
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = IC-2021.1, IC-2022.3, IC-2023.3, IC-2024.1
+pluginVerifierIdeVersions = IC-2022.3, IC-2023.3, IC-2024.1
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # platformType = IC
-platformVersion = 2021.1.3
+platformVersion = 2022.3.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 
 # https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
-# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+# Java language level used to compile sources and to generate the files for - Java 17 is required since 2022.2.
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases 7.6?
 gradleVersion = 7.6.1

--- a/src/main/java/core/ToggleAction.java
+++ b/src/main/java/core/ToggleAction.java
@@ -1,9 +1,7 @@
 package core;
 
 import com.intellij.notification.*;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.project.Project;
@@ -30,6 +28,15 @@ public class ToggleAction extends AnAction {
 
     public ToggleAction(boolean isReverseToggleAction) {
         this.isReverseToggleAction = isReverseToggleAction;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        // BGT is preferred and I see no reason to use EDT instead. See {@link ActionUpdateThread}, this only affects
+        // how {@link AnAction#update(AnActionEvent)} and friends are called.
+        // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides
+        // and: https://github.com/JetBrains/intellij-community/blob/idea/241.15989.150/platform/editor-ui-api/src/com/intellij/openapi/actionSystem/ActionUpdateThread.java#L21
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/src/main/java/core/ToggleAction.java
+++ b/src/main/java/core/ToggleAction.java
@@ -33,6 +33,20 @@ public class ToggleAction extends AnAction {
     }
 
     @Override
+    public void update(@NotNull final AnActionEvent e) {
+        final Project project = e.getProject();
+        final Editor editor = e.getData(CommonDataKeys.EDITOR);
+
+        // Make sure at least one caret is available.
+        boolean menuAllowed = false;
+        if (editor != null && project != null) {
+            // Ensure the list of carets in the editor is not empty.
+            menuAllowed = !editor.getCaretModel().getAllCarets().isEmpty();
+        }
+        e.getPresentation().setEnabledAndVisible(menuAllowed);
+    }
+
+    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         final Editor editor = e.getRequiredData(CommonDataKeys.EDITOR);
         final Project project = e.getRequiredData(CommonDataKeys.PROJECT);
@@ -210,20 +224,6 @@ public class ToggleAction extends AnAction {
         int startOffset = editor.logicalPositionToOffset(new LogicalPosition(currentLine, currentColumnLeftSide));
         int endOffset = editor.logicalPositionToOffset(new LogicalPosition(currentLine, currentColumnRightSide));
         caret.setSelection(startOffset, endOffset);
-    }
-
-    @Override
-    public void update(@NotNull final AnActionEvent e) {
-        final Project project = e.getProject();
-        final Editor editor = e.getData(CommonDataKeys.EDITOR);
-
-        // Make sure at least one caret is available.
-        boolean menuAllowed = false;
-        if (editor != null && project != null) {
-            // Ensure the list of carets in the editor is not empty.
-            menuAllowed = !editor.getCaretModel().getAllCarets().isEmpty();
-        }
-        e.getPresentation().setEnabledAndVisible(menuAllowed);
     }
 
     /**


### PR DESCRIPTION
Bumps the `platformVersion` from `2021.1.3` to `2022.3.1` and Java from `11` to `17`.

Implements the ActionUpdateThread (set to BGT), which addresses the deprecation discussed #64 (see ← for additional context). Note: I was not able to reproduce the mentioned deprecation warning, but neither have I run into any issues with the new version of the plugin.

While the bumps are nice in terms of new API features (both [JetBrains SDK](https://plugins.jetbrains.com/docs/intellij/api-notable-list-2022.html) and Java), the downside is that the minimum supported IDE build has also been bumped from 2021.1 to 2022.3. Looking at the data from [August 2023](https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html)[^1], this could mean that we are cutting out support to (at most) ~18% of the JetBrains userbase (for new versions of the plugin; we used to be compatible with ~93% now ~75%).

[^1]: This is older data, so I assume more users will have adopted these newer IDE versions by now.